### PR TITLE
Refactor Exa tools to Effect-based workflows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "exa-mcp-server",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "exa-mcp-server",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "axios": "^1.7.8",
+        "effect": "^3.17.13",
         "zod": "^3.22.4"
       },
       "bin": {
@@ -61,6 +62,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.17.8",
@@ -362,6 +369,16 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
+    "node_modules/effect": {
+      "version": "3.17.13",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.17.13.tgz",
+      "integrity": "sha512-JMz5oBxs/6mu4FP9Csjub4jYMUwMLrp+IzUmSDVIzn2NoeoyOXMl7x1lghfr3dLKWffWrdnv/d8nFFdgrHXPqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -543,6 +560,28 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -944,6 +983,22 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.13.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
     "axios": "^1.7.8",
+    "effect": "^3.17.13",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/src/tools/companyResearch.ts
+++ b/src/tools/companyResearch.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
-import axios from "axios";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { API_CONFIG } from "./config.js";
-import { ExaSearchRequest, ExaSearchResponse } from "../types.js";
+import { ExaSearchRequest } from "../types.js";
 import { createRequestLogger } from "../utils/logger.js";
+import { runSearchTool } from "../utils/exaEffect.js";
 
 export function registerCompanyResearchTool(server: McpServer, config?: { exaApiKey?: string }): void {
   server.tool(
@@ -19,89 +19,28 @@ export function registerCompanyResearchTool(server: McpServer, config?: { exaApi
       
       logger.start(companyName);
       
-      try {
-        // Create a fresh axios instance for each request
-        const axiosInstance = axios.create({
-          baseURL: API_CONFIG.BASE_URL,
-          headers: {
-            'accept': 'application/json',
-            'content-type': 'application/json',
-            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || ''
+      const searchRequest: ExaSearchRequest = {
+        query: `${companyName} company business corporation information news financial`,
+        type: "neural",
+        numResults: numResults || API_CONFIG.DEFAULT_NUM_RESULTS,
+        contents: {
+          text: {
+            maxCharacters: API_CONFIG.DEFAULT_MAX_CHARACTERS
           },
-          timeout: 25000
-        });
+          livecrawl: 'preferred'
+        },
+        includeDomains: ["bloomberg.com", "reuters.com", "crunchbase.com", "sec.gov", "linkedin.com", "forbes.com", "businesswire.com", "prnewswire.com"]
+      };
 
-        const searchRequest: ExaSearchRequest = {
-          query: `${companyName} company business corporation information news financial`,
-          type: "neural",
-          numResults: numResults || API_CONFIG.DEFAULT_NUM_RESULTS,
-          contents: {
-            text: {
-              maxCharacters: API_CONFIG.DEFAULT_MAX_CHARACTERS
-            },
-            livecrawl: 'preferred'
-          },
-          includeDomains: ["bloomberg.com", "reuters.com", "crunchbase.com", "sec.gov", "linkedin.com", "forbes.com", "businesswire.com", "prnewswire.com"]
-        };
-        
-        logger.log("Sending request to Exa API for company research");
-        
-        const response = await axiosInstance.post<ExaSearchResponse>(
-          API_CONFIG.ENDPOINTS.SEARCH,
-          searchRequest,
-          { timeout: 25000 }
-        );
-        
-        logger.log("Received response from Exa API");
-
-        if (!response.data || !response.data.results) {
-          logger.log("Warning: Empty or invalid response from Exa API");
-          return {
-            content: [{
-              type: "text" as const,
-              text: "No company information found. Please try a different company name."
-            }]
-          };
-        }
-
-        logger.log(`Found ${response.data.results.length} company research results`);
-        
-        const result = {
-          content: [{
-            type: "text" as const,
-            text: JSON.stringify(response.data, null, 2)
-          }]
-        };
-        
-        logger.complete();
-        return result;
-      } catch (error) {
-        logger.error(error);
-        
-        if (axios.isAxiosError(error)) {
-          // Handle Axios errors specifically
-          const statusCode = error.response?.status || 'unknown';
-          const errorMessage = error.response?.data?.message || error.message;
-          
-          logger.log(`Axios error (${statusCode}): ${errorMessage}`);
-          return {
-            content: [{
-              type: "text" as const,
-              text: `Company research error (${statusCode}): ${errorMessage}`
-            }],
-            isError: true,
-          };
-        }
-        
-        // Handle generic errors
-        return {
-          content: [{
-            type: "text" as const,
-            text: `Company research error: ${error instanceof Error ? error.message : String(error)}`
-          }],
-          isError: true,
-        };
-      }
+      return runSearchTool({
+        logger,
+        request: searchRequest,
+        apiKey: config?.exaApiKey,
+        requestLabel: "company research",
+        resultsLabel: "company research results",
+        emptyResultsMessage: "No company information found. Please try a different company name.",
+        errorMessage: "Company research error: Failed to retrieve results from Exa."
+      });
     }
   );
-} 
+}

--- a/src/tools/competitorFinder.ts
+++ b/src/tools/competitorFinder.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
-import axios from "axios";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { API_CONFIG } from "./config.js";
-import { ExaSearchRequest, ExaSearchResponse } from "../types.js";
+import { ExaSearchRequest } from "../types.js";
 import { createRequestLogger } from "../utils/logger.js";
+import { runSearchTool } from "../utils/exaEffect.js";
 
 export function registerCompetitorFinderTool(server: McpServer, config?: { exaApiKey?: string }): void {
   server.tool(
@@ -20,92 +20,31 @@ export function registerCompetitorFinderTool(server: McpServer, config?: { exaAp
       
       logger.start(`${companyName} ${industry ? `in ${industry}` : ''}`);
       
-      try {
-        // Create a fresh axios instance for each request
-        const axiosInstance = axios.create({
-          baseURL: API_CONFIG.BASE_URL,
-          headers: {
-            'accept': 'application/json',
-            'content-type': 'application/json',
-            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || ''
+      const searchQuery = industry
+        ? `${companyName} competitors similar companies ${industry} industry competitive landscape`
+        : `${companyName} competitors similar companies competitive landscape market`;
+
+      const searchRequest: ExaSearchRequest = {
+        query: searchQuery,
+        type: "neural",
+        numResults: numResults || API_CONFIG.DEFAULT_NUM_RESULTS,
+        contents: {
+          text: {
+            maxCharacters: API_CONFIG.DEFAULT_MAX_CHARACTERS
           },
-          timeout: 25000
-        });
-
-        const searchQuery = industry 
-          ? `${companyName} competitors similar companies ${industry} industry competitive landscape`
-          : `${companyName} competitors similar companies competitive landscape market`;
-
-        const searchRequest: ExaSearchRequest = {
-          query: searchQuery,
-          type: "neural",
-          numResults: numResults || API_CONFIG.DEFAULT_NUM_RESULTS,
-          contents: {
-            text: {
-              maxCharacters: API_CONFIG.DEFAULT_MAX_CHARACTERS
-            },
-            livecrawl: 'preferred'
-          }
-        };
-        
-        logger.log("Sending request to Exa API for competitor analysis");
-        
-        const response = await axiosInstance.post<ExaSearchResponse>(
-          API_CONFIG.ENDPOINTS.SEARCH,
-          searchRequest,
-          { timeout: 25000 }
-        );
-        
-        logger.log("Received response from Exa API");
-
-        if (!response.data || !response.data.results) {
-          logger.log("Warning: Empty or invalid response from Exa API");
-          return {
-            content: [{
-              type: "text" as const,
-              text: "No competitor information found. Please try a different company name or industry."
-            }]
-          };
+          livecrawl: 'preferred'
         }
+      };
 
-        logger.log(`Found ${response.data.results.length} competitor analysis results`);
-        
-        const result = {
-          content: [{
-            type: "text" as const,
-            text: JSON.stringify(response.data, null, 2)
-          }]
-        };
-        
-        logger.complete();
-        return result;
-      } catch (error) {
-        logger.error(error);
-        
-        if (axios.isAxiosError(error)) {
-          // Handle Axios errors specifically
-          const statusCode = error.response?.status || 'unknown';
-          const errorMessage = error.response?.data?.message || error.message;
-          
-          logger.log(`Axios error (${statusCode}): ${errorMessage}`);
-          return {
-            content: [{
-              type: "text" as const,
-              text: `Competitor finder error (${statusCode}): ${errorMessage}`
-            }],
-            isError: true,
-          };
-        }
-        
-        // Handle generic errors
-        return {
-          content: [{
-            type: "text" as const,
-            text: `Competitor finder error: ${error instanceof Error ? error.message : String(error)}`
-          }],
-          isError: true,
-        };
-      }
+      return runSearchTool({
+        logger,
+        request: searchRequest,
+        apiKey: config?.exaApiKey,
+        requestLabel: "competitor analysis",
+        resultsLabel: "competitor analysis results",
+        emptyResultsMessage: "No competitor information found. Please try a different company name or industry.",
+        errorMessage: "Competitor finder error: Failed to retrieve results from Exa."
+      });
     }
   );
-} 
+}

--- a/src/tools/config.ts
+++ b/src/tools/config.ts
@@ -2,7 +2,8 @@
 export const API_CONFIG = {
   BASE_URL: 'https://api.exa.ai',
   ENDPOINTS: {
-    SEARCH: '/search'
+    SEARCH: '/search',
+    CONTENTS: '/contents'
   },
   DEFAULT_NUM_RESULTS: 5,
   DEFAULT_MAX_CHARACTERS: 3000

--- a/src/tools/crawling.ts
+++ b/src/tools/crawling.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
-import axios from "axios";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { API_CONFIG } from "./config.js";
+import { ExaCrawlRequest } from "../types.js";
 import { createRequestLogger } from "../utils/logger.js";
+import { runCrawlTool } from "../utils/exaEffect.js";
 
 export function registerCrawlingTool(server: McpServer, config?: { exaApiKey?: string }): void {
   server.tool(
@@ -18,86 +19,25 @@ export function registerCrawlingTool(server: McpServer, config?: { exaApiKey?: s
       
       logger.start(url);
       
-      try {
-        // Create a fresh axios instance for each request
-        const axiosInstance = axios.create({
-          baseURL: API_CONFIG.BASE_URL,
-          headers: {
-            'accept': 'application/json',
-            'content-type': 'application/json',
-            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || ''
+      const crawlRequest: ExaCrawlRequest = {
+        ids: [url],
+        contents: {
+          text: {
+            maxCharacters: maxCharacters || API_CONFIG.DEFAULT_MAX_CHARACTERS
           },
-          timeout: 25000
-        });
-
-        const crawlRequest = {
-          ids: [url],
-          contents: {
-            text: {
-              maxCharacters: maxCharacters || API_CONFIG.DEFAULT_MAX_CHARACTERS
-            },
-            livecrawl: 'preferred'
-          }
-        };
-        
-        logger.log("Sending crawl request to Exa API");
-        
-        const response = await axiosInstance.post(
-          '/contents',
-          crawlRequest,
-          { timeout: 25000 }
-        );
-        
-        logger.log("Received response from Exa API");
-
-        if (!response.data || !response.data.results) {
-          logger.log("Warning: Empty or invalid response from Exa API");
-          return {
-            content: [{
-              type: "text" as const,
-              text: "No content found for the provided URL."
-            }]
-          };
+          livecrawl: 'preferred'
         }
+      };
 
-        logger.log(`Successfully crawled content from URL`);
-        
-        const result = {
-          content: [{
-            type: "text" as const,
-            text: JSON.stringify(response.data, null, 2)
-          }]
-        };
-        
-        logger.complete();
-        return result;
-      } catch (error) {
-        logger.error(error);
-        
-        if (axios.isAxiosError(error)) {
-          // Handle Axios errors specifically
-          const statusCode = error.response?.status || 'unknown';
-          const errorMessage = error.response?.data?.message || error.message;
-          
-          logger.log(`Axios error (${statusCode}): ${errorMessage}`);
-          return {
-            content: [{
-              type: "text" as const,
-              text: `Crawling error (${statusCode}): ${errorMessage}`
-            }],
-            isError: true,
-          };
-        }
-        
-        // Handle generic errors
-        return {
-          content: [{
-            type: "text" as const,
-            text: `Crawling error: ${error instanceof Error ? error.message : String(error)}`
-          }],
-          isError: true,
-        };
-      }
+      return runCrawlTool({
+        logger,
+        request: crawlRequest,
+        apiKey: config?.exaApiKey,
+        requestLabel: "crawl request",
+        emptyResultsMessage: "No content found for the provided URL.",
+        errorMessage: "Crawling error: Failed to retrieve results from Exa.",
+        successLog: () => "Successfully crawled content from URL"
+      });
     }
   );
-} 
+}

--- a/src/tools/githubSearch.ts
+++ b/src/tools/githubSearch.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
-import axios from "axios";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { API_CONFIG } from "./config.js";
-import { ExaSearchRequest, ExaSearchResponse } from "../types.js";
+import { ExaSearchRequest } from "../types.js";
 import { createRequestLogger } from "../utils/logger.js";
+import { runSearchTool } from "../utils/exaEffect.js";
 
 export function registerGithubSearchTool(server: McpServer, config?: { exaApiKey?: string }): void {
   server.tool(
@@ -20,100 +20,39 @@ export function registerGithubSearchTool(server: McpServer, config?: { exaApiKey
       
       logger.start(`${query} (${searchType || 'all'})`);
       
-      try {
-        // Create a fresh axios instance for each request
-        const axiosInstance = axios.create({
-          baseURL: API_CONFIG.BASE_URL,
-          headers: {
-            'accept': 'application/json',
-            'content-type': 'application/json',
-            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || ''
-          },
-          timeout: 25000
-        });
-
-        let searchQuery = query;
-        if (searchType === "repositories") {
-          searchQuery = `${query} GitHub repository`;
-        } else if (searchType === "code") {
-          searchQuery = `${query} GitHub code`;
-        } else if (searchType === "users") {
-          searchQuery = `${query} GitHub user profile`;
-        } else {
-          searchQuery = `${query} GitHub`;
-        }
-
-        const searchRequest: ExaSearchRequest = {
-          query: searchQuery,
-          type: "neural",
-          numResults: numResults || API_CONFIG.DEFAULT_NUM_RESULTS,
-          contents: {
-            text: {
-              maxCharacters: API_CONFIG.DEFAULT_MAX_CHARACTERS
-            },
-            livecrawl: 'preferred'
-          },
-          includeDomains: ["github.com"]
-        };
-        
-        logger.log("Sending request to Exa API for GitHub search");
-        
-        const response = await axiosInstance.post<ExaSearchResponse>(
-          API_CONFIG.ENDPOINTS.SEARCH,
-          searchRequest,
-          { timeout: 25000 }
-        );
-        
-        logger.log("Received response from Exa API");
-
-        if (!response.data || !response.data.results) {
-          logger.log("Warning: Empty or invalid response from Exa API");
-          return {
-            content: [{
-              type: "text" as const,
-              text: "No GitHub content found. Please try a different query."
-            }]
-          };
-        }
-
-        logger.log(`Found ${response.data.results.length} GitHub results`);
-        
-        const result = {
-          content: [{
-            type: "text" as const,
-            text: JSON.stringify(response.data, null, 2)
-          }]
-        };
-        
-        logger.complete();
-        return result;
-      } catch (error) {
-        logger.error(error);
-        
-        if (axios.isAxiosError(error)) {
-          // Handle Axios errors specifically
-          const statusCode = error.response?.status || 'unknown';
-          const errorMessage = error.response?.data?.message || error.message;
-          
-          logger.log(`Axios error (${statusCode}): ${errorMessage}`);
-          return {
-            content: [{
-              type: "text" as const,
-              text: `GitHub search error (${statusCode}): ${errorMessage}`
-            }],
-            isError: true,
-          };
-        }
-        
-        // Handle generic errors
-        return {
-          content: [{
-            type: "text" as const,
-            text: `GitHub search error: ${error instanceof Error ? error.message : String(error)}`
-          }],
-          isError: true,
-        };
+      let searchQuery = query;
+      if (searchType === "repositories") {
+        searchQuery = `${query} GitHub repository`;
+      } else if (searchType === "code") {
+        searchQuery = `${query} GitHub code`;
+      } else if (searchType === "users") {
+        searchQuery = `${query} GitHub user profile`;
+      } else {
+        searchQuery = `${query} GitHub`;
       }
+
+      const searchRequest: ExaSearchRequest = {
+        query: searchQuery,
+        type: "neural",
+        numResults: numResults || API_CONFIG.DEFAULT_NUM_RESULTS,
+        contents: {
+          text: {
+            maxCharacters: API_CONFIG.DEFAULT_MAX_CHARACTERS
+          },
+          livecrawl: 'preferred'
+        },
+        includeDomains: ["github.com"]
+      };
+
+      return runSearchTool({
+        logger,
+        request: searchRequest,
+        apiKey: config?.exaApiKey,
+        requestLabel: "GitHub search",
+        resultsLabel: "GitHub results",
+        emptyResultsMessage: "No GitHub content found. Please try a different query.",
+        errorMessage: "GitHub search error: Failed to retrieve results from Exa."
+      });
     }
   );
-} 
+}

--- a/src/tools/linkedInSearch.ts
+++ b/src/tools/linkedInSearch.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
-import axios from "axios";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { API_CONFIG } from "./config.js";
-import { ExaSearchRequest, ExaSearchResponse } from "../types.js";
+import { ExaSearchRequest } from "../types.js";
 import { createRequestLogger } from "../utils/logger.js";
+import { runSearchTool } from "../utils/exaEffect.js";
 
 export function registerLinkedInSearchTool(server: McpServer, config?: { exaApiKey?: string }): void {
   server.tool(
@@ -20,98 +20,37 @@ export function registerLinkedInSearchTool(server: McpServer, config?: { exaApiK
       
       logger.start(`${query} (${searchType || 'all'})`);
       
-      try {
-        // Create a fresh axios instance for each request
-        const axiosInstance = axios.create({
-          baseURL: API_CONFIG.BASE_URL,
-          headers: {
-            'accept': 'application/json',
-            'content-type': 'application/json',
-            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || ''
-          },
-          timeout: 25000
-        });
-
-        let searchQuery = query;
-        if (searchType === "profiles") {
-          searchQuery = `${query} LinkedIn profile`;
-        } else if (searchType === "companies") {
-          searchQuery = `${query} LinkedIn company`;
-        } else {
-          searchQuery = `${query} LinkedIn`;
-        }
-
-        const searchRequest: ExaSearchRequest = {
-          query: searchQuery,
-          type: "neural",
-          numResults: numResults || API_CONFIG.DEFAULT_NUM_RESULTS,
-          contents: {
-            text: {
-              maxCharacters: API_CONFIG.DEFAULT_MAX_CHARACTERS
-            },
-            livecrawl: 'preferred'
-          },
-          includeDomains: ["linkedin.com"]
-        };
-        
-        logger.log("Sending request to Exa API for LinkedIn search");
-        
-        const response = await axiosInstance.post<ExaSearchResponse>(
-          API_CONFIG.ENDPOINTS.SEARCH,
-          searchRequest,
-          { timeout: 25000 }
-        );
-        
-        logger.log("Received response from Exa API");
-
-        if (!response.data || !response.data.results) {
-          logger.log("Warning: Empty or invalid response from Exa API");
-          return {
-            content: [{
-              type: "text" as const,
-              text: "No LinkedIn content found. Please try a different query."
-            }]
-          };
-        }
-
-        logger.log(`Found ${response.data.results.length} LinkedIn results`);
-        
-        const result = {
-          content: [{
-            type: "text" as const,
-            text: JSON.stringify(response.data, null, 2)
-          }]
-        };
-        
-        logger.complete();
-        return result;
-      } catch (error) {
-        logger.error(error);
-        
-        if (axios.isAxiosError(error)) {
-          // Handle Axios errors specifically
-          const statusCode = error.response?.status || 'unknown';
-          const errorMessage = error.response?.data?.message || error.message;
-          
-          logger.log(`Axios error (${statusCode}): ${errorMessage}`);
-          return {
-            content: [{
-              type: "text" as const,
-              text: `LinkedIn search error (${statusCode}): ${errorMessage}`
-            }],
-            isError: true,
-          };
-        }
-        
-        // Handle generic errors
-        return {
-          content: [{
-            type: "text" as const,
-            text: `LinkedIn search error: ${error instanceof Error ? error.message : String(error)}`
-          }],
-          isError: true,
-        };
+      let searchQuery = query;
+      if (searchType === "profiles") {
+        searchQuery = `${query} LinkedIn profile`;
+      } else if (searchType === "companies") {
+        searchQuery = `${query} LinkedIn company`;
+      } else {
+        searchQuery = `${query} LinkedIn`;
       }
+
+      const searchRequest: ExaSearchRequest = {
+        query: searchQuery,
+        type: "neural",
+        numResults: numResults || API_CONFIG.DEFAULT_NUM_RESULTS,
+        contents: {
+          text: {
+            maxCharacters: API_CONFIG.DEFAULT_MAX_CHARACTERS
+          },
+          livecrawl: 'preferred'
+        },
+        includeDomains: ["linkedin.com"]
+      };
+
+      return runSearchTool({
+        logger,
+        request: searchRequest,
+        apiKey: config?.exaApiKey,
+        requestLabel: "LinkedIn search",
+        resultsLabel: "LinkedIn results",
+        emptyResultsMessage: "No LinkedIn content found. Please try a different query.",
+        errorMessage: "LinkedIn search error: Failed to retrieve results from Exa."
+      });
     }
   );
-} 
+}

--- a/src/tools/webSearch.ts
+++ b/src/tools/webSearch.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
-import axios from "axios";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { API_CONFIG } from "./config.js";
-import { ExaSearchRequest, ExaSearchResponse } from "../types.js";
+import { ExaSearchRequest } from "../types.js";
 import { createRequestLogger } from "../utils/logger.js";
+import { runSearchTool } from "../utils/exaEffect.js";
 
 export function registerWebSearchTool(server: McpServer, config?: { exaApiKey?: string }): void {
   server.tool(
@@ -16,91 +16,28 @@ export function registerWebSearchTool(server: McpServer, config?: { exaApiKey?: 
     async ({ query, numResults }) => {
       const requestId = `web_search_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
       const logger = createRequestLogger(requestId, 'web_search_exa');
-      
       logger.start(query);
-      
-      try {
-        // Create a fresh axios instance for each request
-        const axiosInstance = axios.create({
-          baseURL: API_CONFIG.BASE_URL,
-          headers: {
-            'accept': 'application/json',
-            'content-type': 'application/json',
-            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || ''
+
+      const searchRequest: ExaSearchRequest = {
+        query,
+        type: "auto",
+        numResults: numResults || API_CONFIG.DEFAULT_NUM_RESULTS,
+        contents: {
+          text: {
+            maxCharacters: API_CONFIG.DEFAULT_MAX_CHARACTERS
           },
-          timeout: 25000
-        });
-
-        const searchRequest: ExaSearchRequest = {
-          query,
-          type: "auto",
-          numResults: numResults || API_CONFIG.DEFAULT_NUM_RESULTS,
-          contents: {
-            text: {
-              maxCharacters: API_CONFIG.DEFAULT_MAX_CHARACTERS
-            },
-            livecrawl: 'preferred'
-          }
-        };
-        
-        logger.log("Sending request to Exa API");
-        
-        const response = await axiosInstance.post<ExaSearchResponse>(
-          API_CONFIG.ENDPOINTS.SEARCH,
-          searchRequest,
-          { timeout: 25000 }
-        );
-        
-        logger.log("Received response from Exa API");
-
-        if (!response.data || !response.data.results) {
-          logger.log("Warning: Empty or invalid response from Exa API");
-          return {
-            content: [{
-              type: "text" as const,
-              text: "No search results found. Please try a different query."
-            }]
-          };
+          livecrawl: 'preferred'
         }
+      };
 
-        logger.log(`Found ${response.data.results.length} results`);
-        
-        const result = {
-          content: [{
-            type: "text" as const,
-            text: JSON.stringify(response.data, null, 2)
-          }]
-        };
-        
-        logger.complete();
-        return result;
-      } catch (error) {
-        logger.error(error);
-        
-        if (axios.isAxiosError(error)) {
-          // Handle Axios errors specifically
-          const statusCode = error.response?.status || 'unknown';
-          const errorMessage = error.response?.data?.message || error.message;
-          
-          logger.log(`Axios error (${statusCode}): ${errorMessage}`);
-          return {
-            content: [{
-              type: "text" as const,
-              text: `Search error (${statusCode}): ${errorMessage}`
-            }],
-            isError: true,
-          };
-        }
-        
-        // Handle generic errors
-        return {
-          content: [{
-            type: "text" as const,
-            text: `Search error: ${error instanceof Error ? error.message : String(error)}`
-          }],
-          isError: true,
-        };
-      }
+      return runSearchTool({
+        logger,
+        request: searchRequest,
+        apiKey: config?.exaApiKey,
+        resultsLabel: "results",
+        emptyResultsMessage: "No search results found. Please try a different query.",
+        errorMessage: "Search error: Failed to retrieve results from Exa."
+      });
     }
   );
-} 
+}

--- a/src/tools/wikipediaSearch.ts
+++ b/src/tools/wikipediaSearch.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
-import axios from "axios";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { API_CONFIG } from "./config.js";
-import { ExaSearchRequest, ExaSearchResponse } from "../types.js";
+import { ExaSearchRequest } from "../types.js";
 import { createRequestLogger } from "../utils/logger.js";
+import { runSearchTool } from "../utils/exaEffect.js";
 
 export function registerWikipediaSearchTool(server: McpServer, config?: { exaApiKey?: string }): void {
   server.tool(
@@ -19,89 +19,28 @@ export function registerWikipediaSearchTool(server: McpServer, config?: { exaApi
       
       logger.start(query);
       
-      try {
-        // Create a fresh axios instance for each request
-        const axiosInstance = axios.create({
-          baseURL: API_CONFIG.BASE_URL,
-          headers: {
-            'accept': 'application/json',
-            'content-type': 'application/json',
-            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || ''
+      const searchRequest: ExaSearchRequest = {
+        query: `${query} Wikipedia`,
+        type: "neural",
+        numResults: numResults || API_CONFIG.DEFAULT_NUM_RESULTS,
+        contents: {
+          text: {
+            maxCharacters: API_CONFIG.DEFAULT_MAX_CHARACTERS
           },
-          timeout: 25000
-        });
+          livecrawl: 'preferred'
+        },
+        includeDomains: ["wikipedia.org"]
+      };
 
-        const searchRequest: ExaSearchRequest = {
-          query: `${query} Wikipedia`,
-          type: "neural",
-          numResults: numResults || API_CONFIG.DEFAULT_NUM_RESULTS,
-          contents: {
-            text: {
-              maxCharacters: API_CONFIG.DEFAULT_MAX_CHARACTERS
-            },
-            livecrawl: 'preferred'
-          },
-          includeDomains: ["wikipedia.org"]
-        };
-        
-        logger.log("Sending request to Exa API for Wikipedia search");
-        
-        const response = await axiosInstance.post<ExaSearchResponse>(
-          API_CONFIG.ENDPOINTS.SEARCH,
-          searchRequest,
-          { timeout: 25000 }
-        );
-        
-        logger.log("Received response from Exa API");
-
-        if (!response.data || !response.data.results) {
-          logger.log("Warning: Empty or invalid response from Exa API");
-          return {
-            content: [{
-              type: "text" as const,
-              text: "No Wikipedia articles found. Please try a different query."
-            }]
-          };
-        }
-
-        logger.log(`Found ${response.data.results.length} Wikipedia articles`);
-        
-        const result = {
-          content: [{
-            type: "text" as const,
-            text: JSON.stringify(response.data, null, 2)
-          }]
-        };
-        
-        logger.complete();
-        return result;
-      } catch (error) {
-        logger.error(error);
-        
-        if (axios.isAxiosError(error)) {
-          // Handle Axios errors specifically
-          const statusCode = error.response?.status || 'unknown';
-          const errorMessage = error.response?.data?.message || error.message;
-          
-          logger.log(`Axios error (${statusCode}): ${errorMessage}`);
-          return {
-            content: [{
-              type: "text" as const,
-              text: `Wikipedia search error (${statusCode}): ${errorMessage}`
-            }],
-            isError: true,
-          };
-        }
-        
-        // Handle generic errors
-        return {
-          content: [{
-            type: "text" as const,
-            text: `Wikipedia search error: ${error instanceof Error ? error.message : String(error)}`
-          }],
-          isError: true,
-        };
-      }
+      return runSearchTool({
+        logger,
+        request: searchRequest,
+        apiKey: config?.exaApiKey,
+        requestLabel: "Wikipedia search",
+        resultsLabel: "Wikipedia articles",
+        emptyResultsMessage: "No Wikipedia articles found. Please try a different query.",
+        errorMessage: "Wikipedia search error: Failed to retrieve results from Exa."
+      });
     }
   );
-} 
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,8 +20,17 @@ export interface ExaSearchRequest {
 
 export interface ExaCrawlRequest {
   ids: string[];
-  text: boolean;
-  livecrawl?: 'always' | 'fallback' | 'preferred';
+  contents: {
+    text: {
+      maxCharacters?: number;
+    } | boolean;
+    livecrawl?: 'always' | 'fallback' | 'preferred';
+  };
+}
+
+export interface ExaCrawlResponse {
+  results: Array<Record<string, unknown>>;
+  [key: string]: unknown;
 }
 
 export interface ExaSearchResult {
@@ -48,4 +57,14 @@ export interface SearchArgs {
   query: string;
   numResults?: number;
   livecrawl?: 'always' | 'fallback' | 'preferred';
+}
+
+export interface ToolContent {
+  type: 'text';
+  text: string;
+}
+
+export interface ToolResponse {
+  content: ToolContent[];
+  isError?: boolean;
 }

--- a/src/utils/exaEffect.ts
+++ b/src/utils/exaEffect.ts
@@ -1,0 +1,269 @@
+import axios, { AxiosInstance } from "axios";
+import { Effect, Data } from "effect";
+import { API_CONFIG } from "../tools/config.js";
+import {
+  ExaCrawlRequest,
+  ExaCrawlResponse,
+  ExaSearchRequest,
+  ExaSearchResponse,
+  ToolResponse
+} from "../types.js";
+import { ToolLogger } from "./logger.js";
+
+const DEFAULT_TIMEOUT = 25_000;
+
+export class MissingExaApiKeyError extends Data.TaggedError("MissingExaApiKeyError")<{
+  readonly message: string;
+}> {}
+
+export class ExaRequestError extends Data.TaggedError("ExaRequestError")<{
+  readonly status: number | "unknown";
+  readonly message: string;
+}> {}
+
+export class InvalidExaResponseError extends Data.TaggedError("InvalidExaResponseError")<{
+  readonly message: string;
+}> {}
+
+export type ExaApiError = MissingExaApiKeyError | ExaRequestError | InvalidExaResponseError;
+
+interface ExaRequestOptions {
+  readonly apiKey?: string;
+  readonly timeoutMs?: number;
+}
+
+export const performExaSearch = (
+  request: ExaSearchRequest,
+  options: ExaRequestOptions
+): Effect.Effect<ExaSearchResponse, ExaApiError> =>
+  makeExaPost<ExaSearchRequest, ExaSearchResponse>(API_CONFIG.ENDPOINTS.SEARCH, request, options);
+
+export const performExaCrawl = (
+  request: ExaCrawlRequest,
+  options: ExaRequestOptions
+): Effect.Effect<ExaCrawlResponse, ExaApiError> =>
+  makeExaPost<ExaCrawlRequest, ExaCrawlResponse>(API_CONFIG.ENDPOINTS.CONTENTS, request, options);
+
+const makeExaPost = <TRequest, TResponse>(
+  endpoint: string,
+  payload: TRequest,
+  options: ExaRequestOptions
+): Effect.Effect<TResponse, ExaApiError> =>
+  Effect.gen(function*() {
+    const apiKey = options.apiKey ?? process.env.EXA_API_KEY;
+
+    if (!apiKey) {
+      yield* Effect.fail(
+        new MissingExaApiKeyError({
+          message: "Exa API key is required. Provide it via config.exaApiKey or the EXA_API_KEY environment variable."
+        })
+      );
+    }
+
+    const axiosInstance = yield* Effect.sync((): AxiosInstance =>
+      axios.create({
+        baseURL: API_CONFIG.BASE_URL,
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+          "x-api-key": apiKey
+        },
+        timeout: options.timeoutMs ?? DEFAULT_TIMEOUT
+      })
+    );
+
+    const response = yield* Effect.tryPromise({
+      try: () =>
+        axiosInstance.post<TResponse>(endpoint, payload, {
+          timeout: options.timeoutMs ?? DEFAULT_TIMEOUT
+        }),
+      catch: (error) => {
+        if (axios.isAxiosError(error)) {
+          const status = error.response?.status ?? "unknown";
+          const message =
+            typeof error.response?.data?.message === "string"
+              ? error.response.data.message
+              : error.message;
+
+          return new ExaRequestError({ status, message });
+        }
+
+        return new ExaRequestError({
+          status: "unknown",
+          message: error instanceof Error ? error.message : String(error)
+        });
+      }
+    });
+
+    if (response.data == null) {
+      yield* Effect.fail(
+        new InvalidExaResponseError({
+          message: "Received empty response from Exa API"
+        })
+      );
+    }
+
+    return response.data;
+  });
+
+export const toToolErrorResponse = (
+  error: ExaApiError,
+  fallbackMessage: string
+): ToolResponse => {
+  switch (error._tag) {
+    case "MissingExaApiKeyError":
+      return {
+        content: [
+          {
+            type: "text",
+            text: error.message
+          }
+        ],
+        isError: true
+      };
+    case "ExaRequestError": {
+      const statusLabel = error.status === "unknown" ? "unknown status" : `status ${error.status}`;
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Request to Exa failed (${statusLabel}): ${error.message}`
+          }
+        ],
+        isError: true
+      };
+    }
+    case "InvalidExaResponseError":
+      return {
+        content: [
+          {
+            type: "text",
+            text: fallbackMessage
+          }
+        ],
+        isError: true
+      };
+    default:
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Unexpected error: ${"message" in error ? error.message : fallbackMessage}`
+          }
+        ],
+        isError: true
+      };
+  }
+};
+
+export const formatResults = (data: unknown): ToolResponse => ({
+  content: [
+    {
+      type: "text",
+      text: JSON.stringify(data, null, 2)
+    }
+  ]
+});
+
+interface SearchToolOptions {
+  readonly logger: ToolLogger;
+  readonly request: ExaSearchRequest;
+  readonly apiKey?: string;
+  readonly requestLabel?: string;
+  readonly resultsLabel: string;
+  readonly emptyResultsMessage: string;
+  readonly errorMessage: string;
+}
+
+export const runSearchTool = ({
+  logger,
+  request,
+  apiKey,
+  requestLabel,
+  resultsLabel,
+  emptyResultsMessage,
+  errorMessage
+}: SearchToolOptions): Promise<ToolResponse> => {
+  const labelSuffix = requestLabel ? ` for ${requestLabel}` : "";
+
+  const effect = Effect.gen(function*() {
+    yield* Effect.sync(() => logger.log(`Sending request to Exa API${labelSuffix}`));
+    const response = yield* performExaSearch(request, { apiKey });
+    yield* Effect.sync(() => logger.log(`Received response from Exa API${labelSuffix}`));
+
+    if (!response.results || response.results.length === 0) {
+      yield* Effect.sync(() => logger.log("Warning: Empty or invalid response from Exa API"));
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: emptyResultsMessage
+          }
+        ]
+      } satisfies ToolResponse;
+    }
+
+    yield* Effect.sync(() => logger.log(`Found ${response.results.length} ${resultsLabel}`));
+    yield* Effect.sync(() => logger.complete());
+    return formatResults(response);
+  }).pipe(Effect.tapError((error) => Effect.sync(() => logger.error(error))));
+
+  return Effect.runPromise(
+    Effect.match(effect, {
+      onFailure: (error) => toToolErrorResponse(error, errorMessage),
+      onSuccess: (result) => result
+    })
+  );
+};
+
+interface CrawlToolOptions {
+  readonly logger: ToolLogger;
+  readonly request: ExaCrawlRequest;
+  readonly apiKey?: string;
+  readonly requestLabel?: string;
+  readonly emptyResultsMessage: string;
+  readonly errorMessage: string;
+  readonly successLog?: (response: ExaCrawlResponse) => string;
+}
+
+export const runCrawlTool = ({
+  logger,
+  request,
+  apiKey,
+  requestLabel,
+  emptyResultsMessage,
+  errorMessage,
+  successLog
+}: CrawlToolOptions): Promise<ToolResponse> => {
+  const labelSuffix = requestLabel ? ` for ${requestLabel}` : "";
+
+  const effect = Effect.gen(function*() {
+    yield* Effect.sync(() => logger.log(`Sending request to Exa API${labelSuffix}`));
+    const response = yield* performExaCrawl(request, { apiKey });
+    yield* Effect.sync(() => logger.log(`Received response from Exa API${labelSuffix}`));
+
+    if (!response.results || response.results.length === 0) {
+      yield* Effect.sync(() => logger.log("Warning: Empty or invalid response from Exa API"));
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: emptyResultsMessage
+          }
+        ]
+      } satisfies ToolResponse;
+    }
+
+    const successMessage = successLog ? successLog(response) : `Found ${response.results.length} results`;
+    yield* Effect.sync(() => logger.log(successMessage));
+    yield* Effect.sync(() => logger.complete());
+    return formatResults(response);
+  }).pipe(Effect.tapError((error) => Effect.sync(() => logger.error(error))));
+
+  return Effect.runPromise(
+    Effect.match(effect, {
+      onFailure: (error) => toToolErrorResponse(error, errorMessage),
+      onSuccess: (result) => result
+    })
+  );
+};

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -5,7 +5,14 @@ export const log = (message: string): void => {
   console.error(`[EXA-MCP-DEBUG] ${message}`);
 };
 
-export const createRequestLogger = (requestId: string, toolName: string) => {
+export interface ToolLogger {
+  log: (message: string) => void;
+  start: (query: string) => void;
+  error: (error: unknown) => void;
+  complete: () => void;
+}
+
+export const createRequestLogger = (requestId: string, toolName: string): ToolLogger => {
   return {
     log: (message: string): void => {
       log(`[${requestId}] [${toolName}] ${message}`);
@@ -20,4 +27,4 @@ export const createRequestLogger = (requestId: string, toolName: string) => {
       log(`[${requestId}] [${toolName}] Successfully completed request`);
     }
   };
-}; 
+};


### PR DESCRIPTION
## Summary
- add the Effect runtime and build an Exa API client utility that wraps REST calls with typed errors and reusable runners
- refactor every Exa tool to execute requests through Effect helpers for consistent logging, fallbacks, and error messaging
- expand shared types, logger interfaces, and configuration to support the new Effect-driven pipelines

## Testing
- npm run build:shttp

------
https://chatgpt.com/codex/tasks/task_e_68cd8d5098c88325b1d7ff9192dcfa07